### PR TITLE
Use `<annotationProcessorPath>` for the jpamodelgen dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,11 +55,6 @@
             <version>1.0.0</version>
         </dependency>
         <dependency>
-            <groupId>org.hibernate.orm</groupId>
-            <artifactId>hibernate-jpamodelgen</artifactId>
-            <version>6.6.0.Final</version>
-        </dependency>
-        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-jdbc-postgresql</artifactId>
         </dependency>
@@ -98,6 +93,12 @@
                     <compilerArgs>
                         <arg>-parameters</arg>
                     </compilerArgs>
+                    <annotationProcessorPaths>
+                        <path>
+                            <groupId>org.hibernate.orm</groupId>
+                            <artifactId>hibernate-jpamodelgen</artifactId>
+                        </path>
+                    </annotationProcessorPaths>
                 </configuration>
             </plugin>
             <plugin>


### PR DESCRIPTION
Because it's not normal to have an annotation processor in a runtime classpath, and making the dependency provided would cause problems.

See the recommendations: https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.7#jpamodelgen